### PR TITLE
Fix broken import from pre-0.22.0 sklearn

### DIFF
--- a/notebook/fetcher.py
+++ b/notebook/fetcher.py
@@ -12,7 +12,7 @@
 import os
 import pandas as pd
 
-from sklearn.datasets.base import Bunch
+from sklearn.utils import Bunch
 
 from nilearn.datasets.utils import (_fetch_files,
                                     _get_dataset_dir)
@@ -79,7 +79,7 @@ def fetch_difumo(dimension=64, resolution_mm=2, data_dir=None):
 
     dataset_name = 'difumo_atlases'
 
-    data_dir = _get_dataset_dir(data_dir=None, dataset_name=dataset_name,
+    data_dir = _get_dataset_dir(data_dir=data_dir, dataset_name=dataset_name,
                                 verbose=1)
 
     # Download the zip file, first


### PR DESCRIPTION
This PR fix a broken import (`sklearn.datasets.base`) which occurs in the `demo.ipynb` for scikit-learn >=0.22.0.

## Why the broken import

`base` isn't exposed in sklearn since 0.22.0 so the available code is runnable only with <0.22.0.

## How I fixed it

`sklearn.datasets.base` imports `Bunch` from `sklearn.utils` so I just switched the `Bunch` import from `sklearn.datasets.base` to `sklearn.utils`.
I didn't have to fix the scikit-learn version in the requirements.

## Addition

I fixed the `data_dir` argument of the download function which wasn't used, by passing the argument to the appropriate function.